### PR TITLE
Fix data displayed in report

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.2.1
+  rev: v0.6.7
   hooks:
     # Run the linter.
     - id: ruff

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -112,9 +112,13 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         outdir.mkdir(parents=True)
 
     range_acqs = acqs[(acqs["tstart"] >= tstart) & (acqs["tstart"] < tstop)]
+    two_year_acqs = acqs[
+        (acqs["tstart"] >= (CxoTime(tstop) - 2 * 365 * u.day).secs) & (acqs["tstart"] < tstop)
+    ]
 
     datasets = {
         "all_acq": range_acqs,
+        "two_year_acqs": two_year_acqs,
         "binned_p_acq": utils.BinnedData(
             data=range_acqs,
             bins={"p_acq_model": np.linspace(0, 1, 10)},
@@ -139,7 +143,7 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
 
     plot_params = {
         "acq_stars": {
-            "data": "all_acq",
+            "data": "two_year_acqs",
             "class": "acq_stars_plot",
             "parameters": {"filename": "id_acq_stars.png", "figscale": (2, 1)},
         },
@@ -229,10 +233,7 @@ def mag_scatter_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the 
 
 @utils.mpl_plot()
 def acq_stars_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the decorator)
-    long_acqs = Table(data[data["tstart"] > (CxoTime() - 2 * 365 * u.day).secs])[
-        ["obsid", "acqid", "tstart"]
-    ]
-    acqs_id = long_acqs[long_acqs["acqid"] == 1]
+    acqs_id = data[data["acqid"] == 1]
     gacqs = acqs_id.group_by("obsid")
     n_acqs = gacqs.groups.aggregate(np.size)[["obsid", "acqid"]]
     t_acqs = gacqs.groups.aggregate(np.mean)[["obsid", "tstart"]]

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -116,6 +116,13 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         (acqs["tstart"] >= (CxoTime(tstop) - 2 * 365 * u.day).secs) & (acqs["tstart"] < tstop)
     ]
 
+    t_ccd_bins = np.linspace(-14, 6, 21)
+    if tstart < CxoTime("2020:001").cxcsec:
+        # hack to make sure historicall data fits in the range
+        mt = np.mean(range_acqs["t_ccd"])
+        mt = 2 * np.round(mt / 2)
+        t_ccd_bins = np.linspace(mt - 6, mt + 6, 21)
+
     datasets = {
         "all_acq": range_acqs,
         "two_year_acqs": two_year_acqs,
@@ -125,7 +132,7 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         ),
         "binned_t_ccd": utils.BinnedData(
             data=range_acqs,
-            bins={"t_ccd": np.linspace(-14, 6, 21)},
+            bins={"t_ccd": t_ccd_bins},
         ),
         "binned_mag": utils.BinnedData(
             data=range_acqs,

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -525,6 +525,10 @@ def get_data():
 
 
 def main():
+    import matplotlib
+
+    matplotlib.use("agg")
+
     args = get_parser().parse_args()
 
     logger.setLevel(args.v.upper())

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -124,6 +124,11 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         mt = 2 * np.round(mt / 2)
         t_ccd_bins = np.linspace(mt - 6, mt + 6, 21)
 
+    mag_bins = np.concatenate([
+        np.linspace(5.3, 8.3, 16),
+        [8.5, 8.7, 8.9, 9.2, 9.5, 9.8, 10.2, 12]
+    ])
+
     datasets = {
         "all_acq": range_acqs,
         "two_year_acqs": two_year_acqs,
@@ -134,6 +139,10 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         "binned_t_ccd": utils.BinnedData(
             data=range_acqs,
             bins={"t_ccd": t_ccd_bins},
+        ),
+        "variable_binned_mag": utils.BinnedData(
+            data=range_acqs,
+            bins={"mag": mag_bins},
         ),
         "binned_mag": utils.BinnedData(
             data=range_acqs,
@@ -201,7 +210,7 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
             },
         },
         "mag_pointhist": {
-            "data": "binned_mag",
+            "data": "variable_binned_mag",
             "class": "utils.binned_data_fraction_plot",
             "parameters": {
                 "xlabel": "Star magnitude (mag)",

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -22,7 +22,7 @@ from cxotime import CxoTime
 from ska_helpers import logging
 
 from acq_stat_reports import utils
-from acq_stat_reports.config import OPTIONS
+from acq_stat_reports.config import conf
 
 SKA = Path(os.environ["SKA"])
 
@@ -484,7 +484,7 @@ def get_data():
     # Remove known bad stars
     bad_stars = agasc.get_supplement_table("bad")
     bad = np.isin(all_acq["agasc_id"], bad_stars["agasc_id"]) | all_acq["known_bad"]
-    if OPTIONS.remove_bad_stars:
+    if conf.remove_bad_stars:
         all_acq = all_acq[~bad]
     else:
         all_acq["bad_star"] = bad
@@ -565,8 +565,8 @@ def main():
             "prev": f"{args.url}/{prev_range['year']}/{prev_range['subid']}/index.html",
         }
 
-        OPTIONS.data_dir = str(webout)
-        OPTIONS.close_figures = True
+        conf.data_dir = str(webout)
+        conf.close_figures = True
         make_acq_plots(
             all_acq_upto,
             tstart=range_datestart.secs,

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -279,14 +279,14 @@ def fail_rate_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the de
         y_2_high = np.where(sel, 100 * (d["n"] - d["sigma_2_high"]) / d["n"], np.nan)
         y_2_low = np.where(sel, 100 * (d["n"] - d["sigma_2_low"]) / d["n"], np.nan)
 
-    plt.fill_between(
+    sigma_band_2 = plt.fill_between(
         x,
         utils._mpl_hist_steps(y_2_high),
         utils._mpl_hist_steps(y_2_low),
         alpha=0.25,
         color="gray",
     )
-    plt.fill_between(
+    sigma_band_1 = plt.fill_between(
         x,
         utils._mpl_hist_steps(y_high),
         utils._mpl_hist_steps(y_low),
@@ -294,6 +294,12 @@ def fail_rate_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the de
         color="gray",
     )
     ska_matplotlib.plot_cxctime(d["tstart"], y, ".")
+
+    plt.legend(
+        [sigma_band_1, sigma_band_2],
+        ["68.2% range", "95.4% range"],
+        loc="best",
+    )
 
 
 @utils.mpl_plot(

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -262,8 +262,6 @@ def mag_scatter_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the 
     figscale=(2, 1),
 )
 def fail_rate_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the decorator)
-    import warnings
-
     d = data.binned_data[np.isfinite(data.binned_data["tstart"])]
     sel = d["n"] != 0  # rate will only be plotted where n != 0
     x = utils._mpl_hist_steps(

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -146,7 +146,7 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         ),
         "binned_mag": utils.BinnedData(
             data=range_acqs,
-            bins={"mag": np.arange(5.5 - (0.1 / 2), 12 + (0.1 / 2), 0.1)},
+            bins={"mag": np.arange(5.5 - (0.2 / 2), 12 + (0.2 / 2), 0.2)},
         ),
         "binned_time": utils.BinnedData(
             data=two_year_acqs,

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -125,7 +125,7 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         t_ccd_bins = np.linspace(mt - 6, mt + 6, 21)
 
     mag_bins = np.concatenate(
-        [np.linspace(5.3, 8.3, 16), [8.5, 8.7, 8.9, 9.2, 9.5, 9.8, 10.2, 12]]
+        [np.linspace(5.3, 8.3, 16), [8.5, 8.7, 8.9, 9.2, 9.5, 9.8, 10.2, 11, 12]]
     )
 
     datasets = {

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -124,10 +124,9 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         mt = 2 * np.round(mt / 2)
         t_ccd_bins = np.linspace(mt - 6, mt + 6, 21)
 
-    mag_bins = np.concatenate([
-        np.linspace(5.3, 8.3, 16),
-        [8.5, 8.7, 8.9, 9.2, 9.5, 9.8, 10.2, 12]
-    ])
+    mag_bins = np.concatenate(
+        [np.linspace(5.3, 8.3, 16), [8.5, 8.7, 8.9, 9.2, 9.5, 9.8, 10.2, 12]]
+    )
 
     datasets = {
         "all_acq": range_acqs,
@@ -266,7 +265,7 @@ def fail_rate_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the de
     import warnings
 
     d = data.binned_data[np.isfinite(data.binned_data["tstart"])]
-    sel = (d["n"] != 0)  # rate will only be plotted where n != 0
+    sel = d["n"] != 0  # rate will only be plotted where n != 0
     x = utils._mpl_hist_steps(
         ska_matplotlib.cxctime2plotdate(d["tstart_low"]),
         ska_matplotlib.cxctime2plotdate(d["tstart_high"]),

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -12,7 +12,6 @@ import agasc
 import jinja2
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.stats
 import ska_matplotlib
 import ska_report_ranges
 from astropy import units as u
@@ -356,8 +355,6 @@ def get_acq_info(acqs, tname, range_datestart, range_datestop):
 
     :rtype: dict of report values
     """
-    pred = json.load(open(SKA / "data" / "acq_stat_reports" / "acq_fail_fitfile.json"))
-
     rep = {
         "datestring": tname,
         "datestart": range_datestart.date,
@@ -379,17 +376,18 @@ def get_acq_info(acqs, tname, range_datestart, range_datestop):
     rep["n_failed"] = len(np.flatnonzero(range_acqs["acqid"] == 0))
     rep["fail_rate"] = 1.0 * rep["n_failed"] / rep["n_stars"]
 
-    mean_time = (
-        CxoTime(rep["datestart"]).cxcsec + CxoTime(rep["datestop"]).cxcsec
-    ) / 2.0
-    mean_time_d_year = (mean_time - pred["time0"]) / (86400 * 365.25)
-    rep["fail_rate_pred"] = mean_time_d_year * pred["m"] + pred["b"]
-    rep["n_failed_pred"] = int(round(rep["fail_rate_pred"] * rep["n_stars"]))
+    rep["n_failed_pred"] = len(range_acqs) - np.sum(range_acqs["p_acq_model"])
+    rep["fail_rate_pred"] = rep["n_failed_pred"] / len(range_acqs)
 
-    rep["prob_less"] = scipy.stats.poisson.cdf(rep["n_failed"], rep["n_failed_pred"])
-    rep["prob_more"] = 1 - scipy.stats.poisson.cdf(
-        rep["n_failed"] - 1, rep["n_failed_pred"]
+    samples = (
+        np.random.uniform(size=1000 * len(range_acqs)).reshape((-1, len(range_acqs)))
+        < range_acqs["p_acq_model"][None]
     )
+    n = len(range_acqs) - np.sum(samples, axis=1)
+
+    sigma_1_low, sigma_1_high = np.percentile(n, [15.9, 84.1])
+    rep["prob_less"] = sigma_1_low
+    rep["prob_more"] = sigma_1_high
 
     r, low, high = binomial_confidence_interval(rep["n_failed"], rep["n_stars"])
     rep["fail_rate_err_high"], rep["fail_rate_err_low"] = high - r, r - low

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -285,12 +285,14 @@ def fail_rate_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the de
         utils._mpl_hist_steps(y_2_high),
         utils._mpl_hist_steps(y_2_low),
         alpha=0.25,
+        color="gray",
     )
     plt.fill_between(
         x,
         utils._mpl_hist_steps(y_high),
         utils._mpl_hist_steps(y_low),
         alpha=0.5,
+        color="gray",
     )
     ska_matplotlib.plot_cxctime(d["tstart"], y, ".")
 

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -115,6 +115,10 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
 
     datasets = {
         "all_acq": range_acqs,
+        "binned_p_acq": utils.BinnedData(
+            data=range_acqs,
+            bins={"p_acq_model": np.linspace(0, 1, 10)},
+        ),
         "binned_t_ccd": utils.BinnedData(
             data=range_acqs,
             bins={"t_ccd": np.linspace(-14, 6, 21)},
@@ -130,6 +134,7 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
         "mag_scatter_plot": mag_scatter_plot,
         "utils.binned_data_fraction_plot": utils.binned_data_fraction_plot,
         "utils.binned_data_plot": utils.binned_data_plot,
+        "utils.binned_data_probability_plot": utils.binned_data_probability_plot,
     }
 
     plot_params = {
@@ -191,6 +196,13 @@ def make_acq_plots(acqs, tstart=0, tstop=None, outdir=None):
                 "ylabel": "Fraction Acquired",
                 "title": "Acquisition Success vs T$_{CCD}$",
                 "filename": "t_ccd_pointhist.png",
+            },
+        },
+        "prob_scatter": {
+            "data": "binned_p_acq",
+            "class": "utils.binned_data_probability_plot",
+            "parameters": {
+                "filename": "prob_scatter.png",
             },
         },
     }

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -463,10 +463,10 @@ def main():
     if args.start_time is None:
         to_update = ska_report_ranges.get_update_ranges(args.days_back)
     else:
-        now = CxoTime()
         start = CxoTime(args.start_time)
-        delta = now - start
-        to_update = ska_report_ranges.get_update_ranges(int(delta))
+        to_update = ska_report_ranges.get_update_ranges(
+            int((now - start).to(u.day).value)
+        )
 
     all_acq = get_data()
 

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -264,7 +264,9 @@ def expected_fails_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by t
     ska_matplotlib.plot_cxctime(d["tstart"], d["n"] - d["acqid"], ".")
 
 
-@utils.mpl_plot()
+@utils.mpl_plot(
+    ylabel="Identified acq stars",
+)
 def acq_stars_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the decorator)
     acqs_id = data[data["acqid"] == 1]
     gacqs = acqs_id.group_by("obsid")
@@ -272,10 +274,10 @@ def acq_stars_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the de
     t_acqs = gacqs.groups.aggregate(np.mean)[["obsid", "tstart"]]
     out = join(n_acqs, t_acqs, keys="obsid")
     ska_matplotlib.plot_cxctime(out["tstart"], out["acqid"], ".")
-    plt.grid()
+    plt.yticks([1, 2, 3, 4, 5, 6, 7, 8], minor=True)
+    plt.grid(which="minor", axis="y", color="gray")
+    plt.grid(which="major", axis="x", color="gray")
     plt.ylim(0, 9)
-    plt.margins(0.05)
-    plt.ylabel("Identified acq stars")
 
 
 def make_html(nav_dict, rep_dict, fail_dict, outdir):

--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -275,9 +275,17 @@ def fail_rate_plot(data, **kwargs):  # noqa: ARG001 (kwargs is neeeded by the de
         warnings.filterwarnings("ignore", message="divide by zero")
         warnings.filterwarnings("ignore", message="invalid value encountered in divide")
         y = np.where(sel, 100 * (d["n"] - d["acqid"]) / d["n"], np.nan)
-        y_high = np.where(sel, 100 * (d["n"] - d["high"]) / d["n"], np.nan)
-        y_low = np.where(sel, 100 * (d["n"] - d["low"]) / d["n"], np.nan)
+        y_high = np.where(sel, 100 * (d["n"] - d["sigma_1_high"]) / d["n"], np.nan)
+        y_low = np.where(sel, 100 * (d["n"] - d["sigma_1_low"]) / d["n"], np.nan)
+        y_2_high = np.where(sel, 100 * (d["n"] - d["sigma_2_high"]) / d["n"], np.nan)
+        y_2_low = np.where(sel, 100 * (d["n"] - d["sigma_2_low"]) / d["n"], np.nan)
 
+    plt.fill_between(
+        x,
+        utils._mpl_hist_steps(y_2_high),
+        utils._mpl_hist_steps(y_2_low),
+        alpha=0.25,
+    )
     plt.fill_between(
         x,
         utils._mpl_hist_steps(y_high),

--- a/acq_stat_reports/config.py
+++ b/acq_stat_reports/config.py
@@ -1,0 +1,38 @@
+import astropy.config as _config_
+
+
+class ConfigNamespace(_config_.ConfigNamespace):
+    rootname = "ska_trending"
+
+    data_dir = _config_.ConfigItem(
+        ".",
+        "Top-level data directory",
+    )
+    figure_width = _config_.ConfigItem(
+        5,
+        "Default figure width in inches",
+    )
+    figure_height = _config_.ConfigItem(
+        2.5,
+        "Default figure height in inches",
+    )
+    close_figures = _config_.ConfigItem(
+        False,
+        "Close matplotlib figures after plotting",
+    )
+    remove_bad_stars = _config_.ConfigItem(
+        False,
+        "Do not include bad stars in the reports",
+    )
+    mpl_style = _config_.ConfigItem(
+        "bmh",
+        "Matplotlib style to use",
+    )
+
+    def __str__(self):
+        from pprint import pformat
+
+        return pformat({k: getattr(self, k) for k in self})
+
+
+OPTIONS = ConfigNamespace()

--- a/acq_stat_reports/config.py
+++ b/acq_stat_reports/config.py
@@ -1,38 +1,23 @@
-import astropy.config as _config_
 
 
-class ConfigNamespace(_config_.ConfigNamespace):
-    rootname = "ska_trending"
+class Config:
+    # "Top-level data directory",
+    data_dir = "."
 
-    data_dir = _config_.ConfigItem(
-        ".",
-        "Top-level data directory",
-    )
-    figure_width = _config_.ConfigItem(
-        5,
-        "Default figure width in inches",
-    )
-    figure_height = _config_.ConfigItem(
-        2.5,
-        "Default figure height in inches",
-    )
-    close_figures = _config_.ConfigItem(
-        False,
-        "Close matplotlib figures after plotting",
-    )
-    remove_bad_stars = _config_.ConfigItem(
-        False,
-        "Do not include bad stars in the reports",
-    )
-    mpl_style = _config_.ConfigItem(
-        "bmh",
-        "Matplotlib style to use",
-    )
+    # "Default figure width in inches",
+    figure_width = 5
 
-    def __str__(self):
-        from pprint import pformat
+    # "Default figure height in inches",
+    figure_height = 2.5
 
-        return pformat({k: getattr(self, k) for k in self})
+    # "Close matplotlib figures after plotting",
+    close_figures = False
+
+    # "Do not include bad stars in the reports",
+    remove_bad_stars = False
+
+    # "Matplotlib style to use",
+    mpl_style = "bmh"
 
 
-OPTIONS = ConfigNamespace()
+conf = Config()

--- a/acq_stat_reports/config.py
+++ b/acq_stat_reports/config.py
@@ -1,5 +1,3 @@
-
-
 class Config:
     # "Top-level data directory",
     data_dir = "."

--- a/acq_stat_reports/templates/acq_stats/index.html
+++ b/acq_stat_reports/templates/acq_stats/index.html
@@ -48,10 +48,10 @@
 
 
 <TABLE>
-<TR><TD><img src="mag_histogram.png"></TD><TD><img src="zoom_mag_histogram.png"></TD></TR>
-<TR><TD><img src="mag_pointhist.png"></TD><TD><img src="zoom_mag_pointhist.png"></TD></TR>
+<TR><TD><img src="mag_pointhist.png"></TD><TD><img src="t_ccd_pointhist.png"></TD></TR>
+<TR><TD><img src="mag_histogram.png"></TD><TD><img src="t_ccd_histogram.png"></TD></TR>
 <TR><TD colspan=2><img src="id_acq_stars.png"></TD></TR>
-<TR><TD><img src="exp_mag_histogram.png"></TD><TD><img src="delta_mag_scatter.png"></TD></TR>
+<TR><TD><img src="prob_scatter.png"></TD><TD><img src="delta_mag_scatter.png"></TD></TR>
 </TABLE>
 
 <TABLE BORDER=1>

--- a/acq_stat_reports/templates/acq_stats/index.html
+++ b/acq_stat_reports/templates/acq_stats/index.html
@@ -51,7 +51,7 @@
 <TR><TD><img src="mag_pointhist.png"></TD><TD><img src="t_ccd_pointhist.png"></TD></TR>
 <TR><TD><img src="mag_histogram.png"></TD><TD><img src="t_ccd_histogram.png"></TD></TR>
 <TR><TD colspan=2><img src="id_acq_stars.png"></TD></TR>
-<TR><TD colspan=2><img src="expected_fails_plot.png"></TD></TR>
+<TR><TD colspan=2><img src="fail_rate_plot.png"></TD></TR>
 <TR><TD><img src="prob_scatter.png"></TD><TD><img src="delta_mag_scatter.png"></TD></TR>
 </TABLE>
 

--- a/acq_stat_reports/templates/acq_stats/index.html
+++ b/acq_stat_reports/templates/acq_stats/index.html
@@ -51,6 +51,7 @@
 <TR><TD><img src="mag_pointhist.png"></TD><TD><img src="t_ccd_pointhist.png"></TD></TR>
 <TR><TD><img src="mag_histogram.png"></TD><TD><img src="t_ccd_histogram.png"></TD></TR>
 <TR><TD colspan=2><img src="id_acq_stars.png"></TD></TR>
+<TR><TD colspan=2><img src="expected_fails_plot.png"></TD></TR>
 <TR><TD><img src="prob_scatter.png"></TD><TD><img src="delta_mag_scatter.png"></TD></TR>
 </TABLE>
 

--- a/acq_stat_reports/templates/acq_stats/index.html
+++ b/acq_stat_reports/templates/acq_stats/index.html
@@ -33,7 +33,7 @@
 <TR><TH colspan=2></TH><TH colspan=6>failed_acq</TH></TR>
 <TR><TH></TH><TH></TH><TH colspan=4>stars</TH><TH colspan=2>rate</TH></TR> 
 <TR><TH></TH><TH>n stars</TH><TH>actual</TH><TH>pred.</TH>
-<TH>P Less</TH><TH>P More</TH>
+<TH>q<sub>16</sub></TH><TH>q<sub>84</TH>
 <TH>actual</TH><TH> pred.</TH></TR> 
 <TR><TD>report</TD><TD>{{ rep.n_stars }}</TD>
 {% if rep.n_failed > 0 %}
@@ -41,9 +41,9 @@
 {% else %}
 <TD>{{ rep.n_failed }}</TD>
 {% endif %}
-<TD>{{ rep.n_failed_pred }}</TD>
-<TD>{{ "%.3f"|format(rep.prob_less) }}</TD><TD>{{ "%.3f"|format(rep.prob_more) }}</TD>
-<TD>{{ "%.3f"|format(rep.fail_rate) }}</TD><TD>{{ "%.3f"|format(rep.fail_rate_pred) }}</TD></TR> 
+<TD>{{ "%.2f"|format(rep.n_failed_pred) }}</TD>
+<TD>{{ "%.2f"|format(rep.prob_less) }}</TD><TD>{{ "%.2f"|format(rep.prob_more) }}</TD>
+<TD>{{ "%.2f"|format(rep.fail_rate) }}</TD><TD>{{ "%.2f"|format(rep.fail_rate_pred) }}</TD></TR> 
 </TABLE> 
 
 

--- a/acq_stat_reports/templates/acq_stats/stars.html
+++ b/acq_stat_reports/templates/acq_stats/stars.html
@@ -7,9 +7,9 @@
 {% for star in failed_stars %}
 <TR>
 <TD ALIGN="right">
-<A HREF="https://icxc.harvard.edu/cgi-bin/aspect/get_stats/get_stats.cgi?id={{ star.id }};">{{ star.id }}</A></TD>
+<A HREF="https://kadi.cfa.harvard.edu/star_hist/?agasc_id={{ star.id }}">{{ star.id }}</A></TD>
 <TD ALIGN="right">
-<A HREF="https://icxc.harvard.edu/cgi-bin/aspect/starcheck_print/starcheck_print.cgi?sselect=obsid;obsid1={{ star.obsid }}">{{ star.obsid }}</A></TD>
+<A HREF="https://kadi.cfa.harvard.edu/mica/?obsid_or_date={{ star.obsid }}">{{ star.obsid }}</A></TD>
 <TD ALIGN="right">{{ "%.2f"|format(star.mag_exp) }}</TD>
 {% if star.mag_obs is none %}
 <TD ALIGN="right"></TD>

--- a/acq_stat_reports/tests/test_utils.py
+++ b/acq_stat_reports/tests/test_utils.py
@@ -1,0 +1,176 @@
+import numpy as np
+from astropy.table import Table
+
+from acq_stat_reports import utils
+
+
+def test_histogram():
+    example = Table(
+        {
+            "a": [
+                8.26548573,
+                8.86763105,
+                5.49371611,
+                3.61050205,
+                9.7853743,
+                1.13293811,
+                2.06440575,
+                3.59795432,
+                4.94548012,
+                9.06282222,
+            ],
+            "b": [
+                3.9890854,
+                1.40180462,
+                6.73164771,
+                5.61232687,
+                5.17822797,
+                5.84638758,
+                3.584898,
+                4.53757365,
+                0.4635047,
+                0.36043916,
+            ],
+            "success": [False, False, True, True, True, False, True, True, True, True],
+            "prob": [0.5, 0.9, 0.3, 0.7, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+        }
+    )
+    bin_edges = {
+        "a": np.array([1, 5, 9]),
+        "b": np.array([1, 3.5, 7]),
+    }
+    hist = utils.get_histogram_quantile_ranges(
+        example,
+        bin_edges,
+        success_column="success",
+        prob_column="prob",
+    )
+    cols = [
+        "a",
+        "a_bin",
+        "a_delta",
+        "a_high",
+        "a_low",
+        "a_mean",
+        "a_std",
+        "b",
+        "b_bin",
+        "b_delta",
+        "b_high",
+        "b_low",
+        "b_mean",
+        "b_std",
+        "bin",
+        "high",
+        "low",
+        "median",
+        "n",
+        "success",
+    ]
+    assert cols == sorted(hist.colnames)
+
+    n_a = len(bin_edges["a"]) + 1
+    n_b = len(bin_edges["b"]) + 1
+    assert hist.meta["shape"] == (n_b, n_a)  # note that this is reversed
+    # all bins are there (even empty bins) and none are repeated
+    assert len(hist) == n_a * n_b
+    assert np.unique(hist["a_bin"]).size == len(bin_edges["a"]) + 1
+    assert np.unique(hist["b_bin"]).size == len(bin_edges["b"]) + 1
+    # the global bin ID is sorted and goes from 0 to len(hist) - 1
+    assert np.all(hist["bin"] == np.arange(len(hist)))
+
+    # counts
+    ref = np.array([[0, 1, 0, 1], [0, 0, 1, 0], [0, 4, 2, 1], [0, 0, 0, 0]])
+    assert np.all(ref == np.asarray(hist["n"]).reshape((n_a, n_b)))
+    ref = np.array([[0.0, 1.0, 0.0, 1.0], [0, 0, 0, 0], [0, 3, 1, 1], [0, 0, 0, 0]])
+    assert np.all(ref == np.asarray(hist["success"]).reshape((n_a, n_b)))
+
+    # bin centers along a-axis
+    ref = np.array(
+        [
+            [-np.inf, 3.0, 7.0, np.inf],
+            [-np.inf, 3.0, 7.0, np.inf],
+            [-np.inf, 3.0, 7.0, np.inf],
+            [-np.inf, 3.0, 7.0, np.inf],
+        ]
+    )
+    assert np.all(np.asarray(hist["a"]).reshape((n_a, n_b)) == ref)
+
+    # bin centers along b-axis
+    ref = np.array(
+        [
+            [-np.inf, -np.inf, -np.inf, -np.inf],
+            [2.25, 2.25, 2.25, 2.25],
+            [5.25, 5.25, 5.25, 5.25],
+            [np.inf, np.inf, np.inf, np.inf],
+        ]
+    )
+    assert np.all(np.asarray(hist["b"]).reshape((n_a, n_b)) == ref)
+
+    # quantiles
+    ref = np.array([[0, 1, 0, 1], [0, 0, 1, 0], [0, 4, 2, 1], [0, 0, 0, 0]])
+    assert np.all(np.asarray(hist["high"]).reshape((n_a, n_b)) == ref)
+
+    ref = np.array([[0, 0, 0, 1], [0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0]])
+    assert np.all(np.asarray(hist["low"]).reshape((n_a, n_b)) == ref)
+
+
+def test_histogram_3d():
+    example = Table()
+    a, b, c = np.broadcast_arrays(
+        np.array([0, 1, 2, 3, 4])[None, None, :],
+        np.array([10, 11, 12, 13])[None, :, None],
+        np.array([20, 21, 22])[:, None, None],
+    )
+    example["a"] = a.flatten()
+    example["b"] = b.flatten()
+    example["c"] = c.flatten()
+    example["success"] = True
+    example["prob"] = 1
+
+    bin_edges = {
+        "a": np.array([0.5, 1.5, 2.5, 3.5]),
+        "b": np.array([10.5, 11.5, 12.5]),
+        "c": np.array([20.5, 21.5]),
+    }
+    hist = utils.get_histogram_quantile_ranges(
+        example,
+        bin_edges,
+        success_column="success",
+        prob_column="prob",
+    )
+
+    assert np.all(hist["n"] == 1)
+    assert np.all(hist["success"] == 1)
+
+    cols = [
+        "a",
+        "a_bin",
+        "a_delta",
+        "a_high",
+        "a_low",
+        "a_mean",
+        "a_std",
+        "b",
+        "b_bin",
+        "b_delta",
+        "b_high",
+        "b_low",
+        "b_mean",
+        "b_std",
+        "bin",
+        "c",
+        "c_bin",
+        "c_delta",
+        "c_high",
+        "c_low",
+        "c_mean",
+        "c_std",
+        "high",
+        "low",
+        "median",
+        "n",
+        "success",
+    ]
+
+    assert cols == sorted(hist.colnames)

--- a/acq_stat_reports/tests/test_utils.py
+++ b/acq_stat_reports/tests/test_utils.py
@@ -45,6 +45,7 @@ def test_histogram():
         success_column="success",
         prob_column="prob",
     )
+
     cols = [
         "a",
         "a_bin",
@@ -61,12 +62,15 @@ def test_histogram():
         "b_mean",
         "b_std",
         "bin",
-        "high",
-        "low",
         "median",
         "n",
+        "sigma_1_high",
+        "sigma_1_low",
+        "sigma_2_high",
+        "sigma_2_low",
         "success",
     ]
+
     assert cols == sorted(hist.colnames)
 
     n_a = len(bin_edges["a"]) + 1
@@ -108,11 +112,11 @@ def test_histogram():
     assert np.all(np.asarray(hist["b"]).reshape((n_a, n_b)) == ref)
 
     # quantiles
-    ref = np.array([[0, 1, 0, 1], [0, 0, 1, 0], [0, 4, 2, 1], [0, 0, 0, 0]])
-    assert np.all(np.asarray(hist["high"]).reshape((n_a, n_b)) == ref)
+    ref = np.array([[0, 1, 0, 1], [0, 0, 1, 0], [0, 4, 1, 1], [0, 0, 0, 0]])
+    assert np.all(np.asarray(hist["sigma_1_high"]).reshape((n_a, n_b)) == ref)
 
-    ref = np.array([[0, 0, 0, 1], [0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0]])
-    assert np.all(np.asarray(hist["low"]).reshape((n_a, n_b)) == ref)
+    ref = np.array([[0, 1, 0, 1], [0, 0, 1, 0], [0, 2, 0, 0], [0, 0, 0, 0]])
+    assert np.all(np.asarray(hist["sigma_1_low"]).reshape((n_a, n_b)) == ref)
 
 
 def test_histogram_3d():
@@ -166,11 +170,13 @@ def test_histogram_3d():
         "c_low",
         "c_mean",
         "c_std",
-        "high",
-        "low",
+        "sigma_1_low",
+        "sigma_1_high",
+        "sigma_2_low",
+        "sigma_2_high",
         "median",
         "n",
         "success",
     ]
 
-    assert cols == sorted(hist.colnames)
+    assert sorted(cols) == sorted(hist.colnames)

--- a/acq_stat_reports/utils.py
+++ b/acq_stat_reports/utils.py
@@ -213,9 +213,20 @@ def binned_data_fraction_plot(
     acqid_frac[sel] = quantiles["acqid"][sel] / quantiles["n"][sel]
     low_frac[sel] = quantiles["low"][sel] / quantiles["n"][sel]
     high_frac[sel] = quantiles["high"][sel] / quantiles["n"][sel]
+    acqid_frac[~sel] = np.nan
+    low_frac[~sel] = np.nan
+    high_frac[~sel] = np.nan
 
     plt.plot(quantiles[col], acqid_frac, ".", color="k")
-    plt.fill_between(quantiles[col], low_frac, high_frac, color="gray", alpha=0.8)
+
+    x = _mpl_hist_steps(
+        quantiles[f"{col}_low"],
+        quantiles[f"{col}_high"],
+    )
+    low = _mpl_hist_steps(low_frac)
+    high = _mpl_hist_steps(high_frac)
+
+    plt.fill_between(x, low, high, color="gray", alpha=0.8)
 
     bins = bins[np.isfinite(bins)]
     plt.xlim(bins[0], bins[-1])

--- a/acq_stat_reports/utils.py
+++ b/acq_stat_reports/utils.py
@@ -395,7 +395,7 @@ def get_histogram_quantile_ranges(data, bin_edges, extra_cols=(), n_samples=1000
     # end sanity check
 
     g = data.group_by(bin_cols)
-    assert len(g.groups.indices) < len(quantiles)  # sanity check
+    assert len(g.groups.indices) <= len(quantiles)  # sanity check
     idx = g[["bin"] + cols].groups.aggregate(np.mean)["bin"].astype(int)
     mean = g[cols + extra_cols].groups.aggregate(np.mean)
     std = g[cols + extra_cols].groups.aggregate(np.std)

--- a/acq_stat_reports/utils.py
+++ b/acq_stat_reports/utils.py
@@ -1,0 +1,396 @@
+import functools
+import itertools
+from pathlib import Path
+
+# from typing import Callable
+import matplotlib.pyplot as plt
+import numpy as np
+
+# import numpy.typing as npt
+from astropy.table import Table
+
+from acq_stat_reports.config import OPTIONS
+
+
+class BinnedData:
+    def __init__(self, data, bins, extra_cols=None, selection=None):
+        self.bins = bins
+        self.selection = selection if selection is not None else (lambda x: x)
+        self.data = self.selection(data)
+        self.binned_data = get_histogram_quantile_ranges(
+            self.selection(data),
+            bin_edges=self.bins,
+            extra_cols=[] if extra_cols is None else extra_cols,
+        )
+
+
+def _mpl_hist_steps(arr, arr2=None):
+    """
+    Utility to generate a step plot from histogram values.
+
+    Parameters
+    ----------
+    arr : array-like
+    arr2 : array-like, optional
+
+    Returns
+    -------
+    array-like
+    """
+    if arr2 is None:
+        return np.array([arr, arr]).T.flatten()
+    return np.array([arr, arr2]).T.flatten()
+
+
+def mpl_plot(**defaults):
+    """
+    Decorator to handle common matplotlib plotting tasks.
+    """
+
+    def wrap(func):
+        @functools.wraps(func)
+        def wrapped_function(*args, **kwargs):
+            options = defaults.copy()
+            options.update(kwargs)
+
+            filename = options.pop("filename", None)
+            ax = options.pop("ax", None)
+            close_figures = options.pop("close_figures", OPTIONS.close_figures)
+            figsize = options.pop(
+                "figsize", (OPTIONS.figure_width, OPTIONS.figure_height)
+            )
+            figscale = options.pop("figscale", (1, 1))
+            figscale, _ = np.broadcast_arrays(figscale, [1, 1])
+            figsize = (figsize[0] * figscale[0], figsize[1] * figscale[1])
+
+            outdir = options.pop("outdir", Path(OPTIONS.data_dir))
+
+            with plt.style.context(options.pop("style", OPTIONS.mpl_style)):
+                if ax is None:
+                    fig = plt.figure(figsize=figsize)
+
+                func(*args, **options)
+                plt.xlabel(options.get("xlabel", ""))
+                plt.ylabel(options.get("ylabel", ""))
+                plt.title(options.get("title", ""))
+
+                if options.get("legend", False):
+                    plt.legend(loc="best")
+
+                if ax is None:
+                    plt.tight_layout()
+
+                if outdir and filename:
+                    plt.savefig(outdir / filename)
+                if close_figures:
+                    plt.close(fig)
+
+        return wrapped_function
+
+    return wrap
+
+
+@mpl_plot()
+def binned_data_plot(binned_data: BinnedData, **kwargs):
+    """
+    Plot binned data.
+
+    This function plots histograms of the binned data, where the data must have been binned using
+    a single column. The data is expected to be a Table with columns:
+
+    - `bin`: the bin index
+    - `{col}_low`: the lower edge of the bin
+    - `{col}_high`: the upper edge of the bin
+    - `{col}`: the center of the bin
+    - `{col}_delta`: the width of the bin
+    - `n`: the number of samples in the bin
+    - `acqid`: the number of "good" samples in the bin
+    - `low`: the lower quantile (usually 5%)
+    - `high`: the upper quantile (usually 95%)
+
+    Optional arguments:
+
+    - density. Normalize the histograms.
+    - draw_good. Draw a histogram of the "good" samples.
+    - draw_bad. Draw a histogram of the "bad" samples.
+    - draw_ranges. Draw a shaded region between the lower and upper quantiles.
+
+    """
+    if len(binned_data.bins) > 1:
+        raise Exception("Only one axis allowed in binned_data_plot")
+    bins = list(binned_data.bins.values())[0]
+    col = list(binned_data.bins.keys())[0]
+    density = kwargs.get("density", False)
+    draw_good = kwargs.get("draw_good", False)
+    draw_bad = kwargs.get("draw_bad", False)
+    draw_ranges = kwargs.get("draw_ranges", False)
+
+    quantiles = binned_data.binned_data
+    x = _mpl_hist_steps(quantiles[f"{col}_low"], quantiles[f"{col}_high"])
+    y1 = _mpl_hist_steps(quantiles["low"])
+    y2 = _mpl_hist_steps(quantiles["high"])
+    n = _mpl_hist_steps(quantiles["n"])
+    acqid = _mpl_hist_steps(quantiles["acqid"])
+    diff = _mpl_hist_steps(quantiles[f"{col}_delta"])
+
+    if draw_good and np.any(binned_data.data["acqid"]):
+        scale = 1 / (diff * np.sum(quantiles["acqid"])) if density else 1
+        if draw_ranges:
+            plt.fill_between(
+                x,
+                scale * y1,
+                scale * y2,
+                color="gray",
+                alpha=0.8,
+            )
+        plt.plot(
+            x,
+            scale * acqid,
+            "-",
+            color="k",
+            label="Acquired",
+        )
+
+    if draw_bad and np.any(~binned_data.data["acqid"]):
+        scale = 1 / (diff * np.sum(n - acqid)) if density else 1
+        if draw_ranges:
+            plt.fill_between(
+                x,
+                scale * (n - y1),
+                scale * (n - y2),
+                color="r",
+                alpha=0.3,
+            )
+        plt.plot(
+            x,
+            scale * (n - acqid),
+            "-",
+            color="r",
+            label="Not Acquired",
+        )
+
+    bins = bins[np.isfinite(bins)]
+    plt.xlim(bins[0], bins[-1])
+    plt.ylim(ymin=0)
+
+
+@mpl_plot()
+def binned_data_fraction_plot(
+    binned_data: BinnedData,
+    **kwargs,  # noqa: ARG001 (kwargs is neeeded by the decorator)
+):
+    """
+    Plot binned data.
+
+    This function plots ratios from the binned data (acqid/n), where the data must have been binned
+    using a single column. The data is expected to be a Table with columns:
+
+    - `bin`: the bin index
+    - `{col}_low`: the lower edge of the bin
+    - `{col}_high`: the upper edge of the bin
+    - `{col}`: the center of the bin
+    - `{col}_delta`: the width of the bin
+    - `n`: the number of samples in the bin
+    - `acqid`: the number of "good" samples in the bin
+    - `low`: the lower quantile (usually 5%)
+    - `high`: the upper quantile (usually 95%)
+
+    The plot includes a shaded region between the lower and upper quantiles (low/n and high/n).
+
+    """
+    if len(binned_data.bins) > 1:
+        raise Exception("Only one axis allowed in FractionPlot")
+    bins = list(binned_data.bins.values())[0]
+    col = list(binned_data.bins.keys())[0]
+
+    quantiles = binned_data.binned_data
+
+    sel = quantiles["n"] > 0
+    acqid_frac = np.zeros(len(quantiles))
+    low_frac = np.zeros(len(quantiles))
+    high_frac = np.zeros(len(quantiles))
+    acqid_frac[sel] = quantiles["acqid"][sel] / quantiles["n"][sel]
+    low_frac[sel] = quantiles["low"][sel] / quantiles["n"][sel]
+    high_frac[sel] = quantiles["high"][sel] / quantiles["n"][sel]
+
+    plt.plot(quantiles[col], acqid_frac, ".", color="k")
+    plt.fill_between(quantiles[col], low_frac, high_frac, color="gray", alpha=0.8)
+
+    bins = bins[np.isfinite(bins)]
+    plt.xlim(bins[0], bins[-1])
+    plt.ylim(-0.05, 1.05)
+
+
+def _get_quantiles_(p_acq_model, n_realizations=10000):
+    """
+    Generate the 5th, 50th, and 95th percentiles of the expected number of successes in a series.
+
+    This function assumes the input is an array of probabilities, one for each draw.
+    It generates `n_realizations` realizations , and uses them to estimate the percentiles.
+
+    Parameters
+    ----------
+    p_acq_model : array-like
+        The binomial probability.
+    n_realizations : int, optional
+        The number of realizations of the series to use for the Monte Carlo estimation.
+
+    Returns
+    -------
+    array-like
+        The quantiles
+    """
+    samples = (
+        np.random.uniform(size=n_realizations * len(p_acq_model)).reshape(
+            (-1, len(p_acq_model))
+        )
+        < p_acq_model[None]
+    )
+    n = np.sum(samples, axis=1)
+    return np.percentile(n, [5, 50, 95])
+
+
+def get_histogram_quantile_ranges(data, bin_edges, extra_cols=(), n_samples=10000):  # noqa: PLR0915
+    """
+    Summarize data in bins and calculate quantiles.
+
+    This function expects a Table with `acqid` and `p_acq_model` columns. The `acqid` column tells
+    whether this sample is a success, and `p_acq_model` is the a-priori probability of success.
+
+    The function bins the data according to the columns given in `bin_edges`, and creates the
+    following columns:
+    - `bin`: the unique bin index
+    - `n`: the number of samples in the bin
+    - `{col}_low`: the lower edge of the bin (repeated for all bin_edges keys)
+    - `{col}_high`: the upper edge of the bin (repeated for all bin_edges keys)
+    - `{col}`: the center of the bin (repeated for all bin_edges keys)
+    - `{col}_delta`: the width of the bin (repeated for all bin_edges keys)
+    - `acqid`: the number of "good" samples in the bin
+    - `low`: the lower quantile (usually 5%)
+    - `median`: the median
+    - `high`: the upper quantile (usually 95%)
+
+    NOTE: the result is NOT sparse (it will contain all bins, even if there are no samples in it).
+
+    Parameters
+    ----------
+    data : Table
+        The data to summarize. Must include a `p_acq_model` column and the corresponding columns
+        for the bin edges.
+    bin_edges : dict
+        A dictionary of bin edges for each column.
+    n_samples : int, optional
+        The number of realizations to use in the Monte Carlo estimation of the expected successes.
+
+    Returns
+    -------
+    Table
+        The quantiles of the data in the bins.
+    """
+    cols = list(bin_edges)
+    bin_cols = [f"{bin_col}_bin" for bin_col in cols]
+    for bin_col in cols:
+        bin_edges[bin_col] = np.atleast_1d(bin_edges[bin_col])
+        if len(bin_edges[bin_col].shape) != 1:
+            raise ValueError("bin_edges must be a dict of 1D arrays")
+
+    # data = data.copy()
+    bin_edges = bin_edges.copy()
+
+    # for bin_col in cols:
+    #     # no underflow (otherwise I one has to be careful with bin == 0)
+    #     data = data[data[bin_col] > bin_edges[bin_col][0]]
+
+    sizes = [len(b) for b in bin_edges.values()]
+    offsets = {cols[0]: 0}
+    offsets.update({cols[i]: np.prod(sizes[:i]) for i in range(1, len(cols))})
+
+    global_bin_idx = np.zeros(len(data), dtype=int)
+    for bin_col in cols:
+        data[f"{bin_col}_bin"] = np.digitize(data[bin_col], bin_edges[bin_col])
+        global_bin_idx += offsets[bin_col] + data[f"{bin_col}_bin"]
+    data["bin"] = global_bin_idx
+
+    # now this is very inefficient, because we are making a list of all possible combinations of bin
+    # indices. Note that we are iterating over cols in reverse order so that the bin calculation
+    # agrees with the one on the data array.
+    bin_idx = dict(
+        zip(
+            cols[::-1],
+            np.array(
+                list(
+                    zip(
+                        *[
+                            list(j)
+                            for j in itertools.product(
+                                *[range(len(bin_edges[col]) + 1) for col in cols[::-1]]
+                            )
+                        ],
+                        strict=True,
+                    )
+                )
+            ),
+            strict=True,
+        )
+    )
+
+    # bins are the bin edges, and np.digitize returns indices assuming there are (n_bins - 1) bins,
+    # plus the under/overflow bins. That's (n_bins + 1) bins.
+    # for book-keeping, we will create padded arrays with -inf and +inf
+    padded_bins = {
+        col: np.concatenate([[-np.inf], bin_edges[col], [np.inf]]) for col in cols
+    }
+
+    quantiles = Table()
+    quantiles["bin"] = np.arange(len(bin_idx[cols[0]]))
+    for bin_col in cols:
+        j = bin_idx[bin_col]
+        quantiles[f"{bin_col}_bin"] = j
+        quantiles[f"{bin_col}_low"] = padded_bins[bin_col][j]
+        quantiles[f"{bin_col}_high"] = padded_bins[bin_col][j + 1]
+        quantiles[f"{bin_col}"] = (
+            quantiles[f"{bin_col}_low"] + quantiles[f"{bin_col}_high"]
+        ) / 2
+
+    # this is a sanity check that the bin indices as calculated above are correct
+    global_bin_idx = np.zeros(len(quantiles), dtype=int)
+    for bin_col in cols:
+        global_bin_idx += offsets[bin_col] + quantiles[f"{bin_col}_bin"]
+    assert np.all(quantiles["bin"] == global_bin_idx)
+    # end sanity check
+
+    g = data.group_by(bin_cols)
+    assert len(g.groups.indices) < len(quantiles)  # sanity check
+    idx = g[["bin"] + cols].groups.aggregate(np.mean)["bin"].astype(int)
+    mean = g[cols + extra_cols].groups.aggregate(np.mean)
+    std = g[cols + extra_cols].groups.aggregate(np.std)
+    n = np.diff(g.groups.indices)
+    acqid = g["acqid"].groups.aggregate(np.count_nonzero)
+    low, median, high = np.vstack(
+        [_get_quantiles_(group["p_acq_model"], n_samples) for group in g.groups]
+    ).T
+
+    quantiles["low"] = 0
+    quantiles["median"] = 0
+    quantiles["high"] = 0
+    quantiles["n"] = 0
+    quantiles["acqid"] = 0
+
+    quantiles["low"][idx] = low
+    quantiles["median"][idx] = median
+    quantiles["high"][idx] = high
+    quantiles["n"][idx] = n
+    quantiles["acqid"][idx] = acqid
+
+    for col in cols:
+        quantiles[f"{col}_mean"] = np.nan
+        quantiles[f"{col}_mean"][idx] = mean[col]
+        quantiles[f"{col}_delta"] = quantiles[f"{col}_high"] - quantiles[f"{col}_low"]
+        quantiles[f"{col}_std"] = np.nan
+        quantiles[f"{col}_std"][idx] = std[col]
+    for col in extra_cols:
+        quantiles[f"{col}_mean"] = np.nan
+        quantiles[f"{col}_mean"][idx] = mean[col]
+        quantiles[f"{col}_std"] = np.nan
+        quantiles[f"{col}_std"][idx] = std[col]
+    return quantiles

--- a/acq_stat_reports/utils.py
+++ b/acq_stat_reports/utils.py
@@ -10,7 +10,7 @@ import numpy as np
 from astropy.table import Table
 from chandra_aca.star_probs import binomial_confidence_interval
 
-from acq_stat_reports.config import OPTIONS
+from acq_stat_reports.config import conf
 
 
 class BinnedData:
@@ -56,17 +56,17 @@ def mpl_plot(**defaults):
 
             filename = options.pop("filename", None)
             ax = options.pop("ax", None)
-            close_figures = options.pop("close_figures", OPTIONS.close_figures)
+            close_figures = options.pop("close_figures", conf.close_figures)
             figsize = options.pop(
-                "figsize", (OPTIONS.figure_width, OPTIONS.figure_height)
+                "figsize", (conf.figure_width, conf.figure_height)
             )
             figscale = options.pop("figscale", (1, 1))
             figscale, _ = np.broadcast_arrays(figscale, [1, 1])
             figsize = (figsize[0] * figscale[0], figsize[1] * figscale[1])
 
-            outdir = options.pop("outdir", Path(OPTIONS.data_dir))
+            outdir = options.pop("outdir", Path(conf.data_dir))
 
-            with plt.style.context(options.pop("style", OPTIONS.mpl_style)):
+            with plt.style.context(options.pop("style", conf.mpl_style)):
                 if ax is None:
                     fig = plt.figure(figsize=figsize)
 

--- a/acq_stat_reports/utils.py
+++ b/acq_stat_reports/utils.py
@@ -105,8 +105,10 @@ def binned_data_plot(binned_data: BinnedData, **kwargs):
     - `{col}_delta`: the width of the bin
     - `n`: the number of samples in the bin
     - `acqid`: the number of "good" samples in the bin
-    - `low`: the lower quantile (usually 5%)
-    - `high`: the upper quantile (usually 95%)
+    - `sigma_1_low`: the lower 1-sigma quantile (usually 15.9%)
+    - `sigma_1_high`: the upper 1-sigma quantile (usually 84.1%)
+    - `sigma_2_low`: the lower 2-sigma quantile (usually 2.27%)
+    - `sigma_2_high`: the upper 2-sigma quantile (usually 97.7%)
 
     Optional arguments:
 
@@ -231,8 +233,10 @@ def binned_data_fraction_plot(
     - `{col}_delta`: the width of the bin
     - `n`: the number of samples in the bin
     - `acqid`: the number of "good" samples in the bin
-    - `low`: the lower quantile (usually 5%)
-    - `high`: the upper quantile (usually 95%)
+    - `sigma_1_low`: the lower 1-sigma quantile (usually 15.9%)
+    - `sigma_1_high`: the upper 1-sigma quantile (usually 84.1%)
+    - `sigma_2_low`: the lower 2-sigma quantile (usually 2.27%)
+    - `sigma_2_high`: the upper 2-sigma quantile (usually 97.7%)
 
     The plot includes a shaded region between the lower and upper quantiles (low/n and high/n).
 
@@ -384,9 +388,11 @@ def get_histogram_quantile_ranges(  # noqa: PLR0915
     - `{col}`: the center of the bin (repeated for all bin_edges keys)
     - `{col}_delta`: the width of the bin (repeated for all bin_edges keys)
     - `{success_column}`: the number of "good" samples in the bin
-    - `low`: the lower quantile (usually 5%)
     - `median`: the median
-    - `high`: the upper quantile (usually 95%)
+    - `sigma_1_low`: the lower 1-sigma quantile (15.9%)
+    - `sigma_1_high`: the upper 1-sigma quantile (84.1%)
+    - `sigma_2_low`: the lower 2-sigma quantile (2.27%)
+    - `sigma_2_high`: the upper 2-sigma quantile (97.7%)
 
     NOTE: the result is NOT sparse (it will contain all bins, even if there are no samples in it).
 

--- a/acq_stat_reports/utils.py
+++ b/acq_stat_reports/utils.py
@@ -57,9 +57,7 @@ def mpl_plot(**defaults):
             filename = options.pop("filename", None)
             ax = options.pop("ax", None)
             close_figures = options.pop("close_figures", conf.close_figures)
-            figsize = options.pop(
-                "figsize", (conf.figure_width, conf.figure_height)
-            )
+            figsize = options.pop("figsize", (conf.figure_width, conf.figure_height))
             figscale = options.pop("figscale", (1, 1))
             figscale, _ = np.broadcast_arrays(figscale, [1, 1])
             figsize = (figsize[0] * figscale[0], figsize[1] * figscale[1])

--- a/acq_stat_reports/utils.py
+++ b/acq_stat_reports/utils.py
@@ -293,7 +293,7 @@ def _get_quantiles_(p_acq_model, n_realizations=10000):
         < p_acq_model[None]
     )
     n = np.sum(samples, axis=1)
-    return np.percentile(n, [5, 50, 95])
+    return np.percentile(n, [15.9, 50, 84.1])
 
 
 def get_histogram_quantile_ranges(  # noqa: PLR0915


### PR DESCRIPTION
## Description

This PR changes the data displayed in the tables in the report. Instead of using a file in `SKA/data/ac_stat_report` to give the expected number of failures, it now uses the `p_acq_model` column.

This PR also:
- replaces the links to cgi scripts with links to kadi
- decouples the fetching of acq info and writing html
- merges the two output JSON files into a single file.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
