### PR TITLE
Fix data

### DIFF
--- a/acq_stat_reports/acq_stat_reports.py
+++ b/acq_stat_reports/acq_stat_reports.py
@@ -12,7 +12,6 @@ import agasc
 import jinja2
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.stats
 import ska_matplotlib
 import ska_report_ranges
 from astropy import units as u
@@ -356,8 +355,6 @@ def get_acq_info(acqs, tname, range_datestart, range_datestop):
 
     :rtype: dict of report values
     """
-    pred = json.load(open(SKA / "data" / "acq_stat_reports" / "acq_fail_fitfile.json"))
-
     rep = {
         "datestring": tname,
         "datestart": range_datestart.date,
@@ -379,17 +376,18 @@ def get_acq_info(acqs, tname, range_datestart, range_datestop):
     rep["n_failed"] = len(np.flatnonzero(range_acqs["acqid"] == 0))
     rep["fail_rate"] = 1.0 * rep["n_failed"] / rep["n_stars"]
 
-    mean_time = (
-        CxoTime(rep["datestart"]).cxcsec + CxoTime(rep["datestop"]).cxcsec
-    ) / 2.0
-    mean_time_d_year = (mean_time - pred["time0"]) / (86400 * 365.25)
-    rep["fail_rate_pred"] = mean_time_d_year * pred["m"] + pred["b"]
-    rep["n_failed_pred"] = int(round(rep["fail_rate_pred"] * rep["n_stars"]))
+    rep["n_failed_pred"] = len(range_acqs) - np.sum(range_acqs["p_acq_model"])
+    rep["fail_rate_pred"] = rep["n_failed_pred"] / len(range_acqs)
 
-    rep["prob_less"] = scipy.stats.poisson.cdf(rep["n_failed"], rep["n_failed_pred"])
-    rep["prob_more"] = 1 - scipy.stats.poisson.cdf(
-        rep["n_failed"] - 1, rep["n_failed_pred"]
+    samples = (
+        np.random.uniform(size=1000 * len(range_acqs)).reshape((-1, len(range_acqs)))
+        < range_acqs["p_acq_model"][None]
     )
+    n = len(range_acqs) - np.sum(samples, axis=1)
+
+    sigma_1_low, sigma_1_high = np.percentile(n, [15.9, 84.1])
+    rep["prob_less"] = sigma_1_low
+    rep["prob_more"] = sigma_1_high
 
     r, low, high = binomial_confidence_interval(rep["n_failed"], rep["n_stars"])
     rep["fail_rate_err_high"], rep["fail_rate_err_low"] = high - r, r - low

--- a/acq_stat_reports/templates/acq_stats/index.html
+++ b/acq_stat_reports/templates/acq_stats/index.html
@@ -33,7 +33,7 @@
 <TR><TH colspan=2></TH><TH colspan=6>failed_acq</TH></TR>
 <TR><TH></TH><TH></TH><TH colspan=4>stars</TH><TH colspan=2>rate</TH></TR> 
 <TR><TH></TH><TH>n stars</TH><TH>actual</TH><TH>pred.</TH>
-<TH>P Less</TH><TH>P More</TH>
+<TH>q<sub>16</sub></TH><TH>q<sub>84</TH>
 <TH>actual</TH><TH> pred.</TH></TR> 
 <TR><TD>report</TD><TD>{{ rep.n_stars }}</TD>
 {% if rep.n_failed > 0 %}
@@ -41,9 +41,9 @@
 {% else %}
 <TD>{{ rep.n_failed }}</TD>
 {% endif %}
-<TD>{{ rep.n_failed_pred }}</TD>
-<TD>{{ "%.3f"|format(rep.prob_less) }}</TD><TD>{{ "%.3f"|format(rep.prob_more) }}</TD>
-<TD>{{ "%.3f"|format(rep.fail_rate) }}</TD><TD>{{ "%.3f"|format(rep.fail_rate_pred) }}</TD></TR> 
+<TD>{{ "%.2f"|format(rep.n_failed_pred) }}</TD>
+<TD>{{ "%.2f"|format(rep.prob_less) }}</TD><TD>{{ "%.2f"|format(rep.prob_more) }}</TD>
+<TD>{{ "%.2f"|format(rep.fail_rate) }}</TD><TD>{{ "%.2f"|format(rep.fail_rate_pred) }}</TD></TR> 
 </TABLE> 
 
 

--- a/acq_stat_reports/templates/acq_stats/stars.html
+++ b/acq_stat_reports/templates/acq_stats/stars.html
@@ -7,9 +7,9 @@
 {% for star in failed_stars %}
 <TR>
 <TD ALIGN="right">
-<A HREF="https://icxc.harvard.edu/cgi-bin/aspect/get_stats/get_stats.cgi?id={{ star.id }};">{{ star.id }}</A></TD>
+<A HREF="https://kadi.cfa.harvard.edu/star_hist/?agasc_id={{ star.id }}">{{ star.id }}</A></TD>
 <TD ALIGN="right">
-<A HREF="https://icxc.harvard.edu/cgi-bin/aspect/starcheck_print/starcheck_print.cgi?sselect=obsid;obsid1={{ star.obsid }}">{{ star.obsid }}</A></TD>
+<A HREF="https://kadi.cfa.harvard.edu/mica/?obsid_or_date={{ star.obsid }}">{{ star.obsid }}</A></TD>
 <TD ALIGN="right">{{ "%.2f"|format(star.mag_exp) }}</TD>
 {% if star.mag_obs is none %}
 <TD ALIGN="right"></TD>


### PR DESCRIPTION
## Description

This PR changes the data displayed in the tables in the report. Instead of using a file in `SKA/data/ac_stat_report` to give the expected number of failures, it now uses the `p_acq_model` column.

This PR also:
- replaces the links to cgi scripts with links to kadi
- decouples the fetching of acq info and writing html
- merges the two output JSON files into a single file.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
